### PR TITLE
Feat: Rewrite Hooking System for Clarity and Flexibility

### DIFF
--- a/include/plugin.h
+++ b/include/plugin.h
@@ -14,7 +14,7 @@ namespace Syringe {
 
     public:
         Plugin(const char* path);
-        gfModule* loadPlugin();
+        gfModule* loadPlugin(CoreApi* api);
         void unloadPlugin();
         bool isEnabled() { return enable; }
         // plgParam* getParam(const char* name);

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -13,7 +13,7 @@ namespace Syringe {
         strncpy(this->path, path, sizeof(this->path));
     }
 
-    gfModule* Plugin::loadPlugin()
+    gfModule* Plugin::loadPlugin(CoreApi* api)
     {
         gfFileIOHandle handle;
         handle.read(this->path, Heaps::MenuInstance, 0);
@@ -31,7 +31,7 @@ namespace Syringe {
         // Normally module prolog doesn't return anything, but in our case we stipulate
         // that it returns a pointer to the plugin metadata struct and takes the API as an argument
         PluginPrologFN prolog = reinterpret_cast<PluginPrologFN>(this->module->header->prologOffset);
-        this->metadata = prolog(SyringeCore::API);
+        this->metadata = prolog(api);
 
         char buff[10];
         if (this->metadata->SY_VERSION != Version(SYRINGE_VERSION))

--- a/source/rel.cpp
+++ b/source/rel.cpp
@@ -50,7 +50,7 @@ namespace Syringe {
 
         // try and apply rel hooks to modules which
         // were already loaded before loading plugins
-        // SyringeCore::applyRelHooks();
+        // SyringeCore::hookLoadedModules();
     }
 
     void _epilog()


### PR DESCRIPTION
## What this does
This PR rewrites the hooking system for additional clarity, maintainability, and flexibility. Specifically, this PR implements the following changes:
 - Refactors hook types to use a single `Hook` class instead of several classes and polymorphism.
 - Hooks now take an option / flags field that can be used to customize the hook behavior on a deeper level
 - Implements a new developer facing API method `syCustomHook` that exposes the hook flags to the developer, allowing more flexible hook usage.
 - Changes `syReplaceFunc` to patch a branch directly to the function replacement rather than to an intermediary trampoline.