### PR TITLE
Strip debug logging if `LOGGING` not defined.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ LD 			:= $(TOPDIR)/tools/MWCC4_2/mwldeppc.exe
 ELF2REL		:= $(TOPDIR)/tools/elf2rel.exe
 
 
-CCFLAGS		:= -msgstyle gcc -Cpp_exceptions off -c -use_lmw_stmw on -RTTI off -proc gekko -nostdinc -O4,s -enum int -fp hard -u _prolog -u _epilog -u _unresolved -sdata 0 -sdata2 0 -func_align 4 -rostr
+CCFLAGS		:= -msgstyle gcc -Cpp_exceptions off -c -use_lmw_stmw on -RTTI off -proc gekko -nostdinc -O4,s -enum int -fp hard -u _prolog -u _epilog -u _unresolved -sdata 0 -sdata2 0 -func_align 4 -rostr -DLOGGING
 CXXFLAGS	:= -lang=c++ $(CCFLAGS)
 LDFLAGS		:= -lcf $(LCF) -r1 -fp hard -m _prolog -g
 

--- a/include/sy_utils.hpp
+++ b/include/sy_utils.hpp
@@ -2,8 +2,38 @@
 
 #include <types.h>
 
+// Compile-time logging gate.
+// Define LOGGING to enable log output; omit to strip all log callsites
+// and their string literals from the binary, reducing code size.
+#ifdef LOGGING
+#include <OS/OSError.h>
+#include <stdio.h>
+inline void SY_LOG_IMPL(const char* fmt, ...)
+{
+    char buf[256];
+
+    // Manually inject the prefix into the buffer so one OSReport call emits
+    // the fully formatted message.
+    char* p = buf;
+    const char* prefix = "[Syringe] ";
+    while (*prefix)
+        *p++ = *prefix++;
+
+    va_list args;
+    va_start(args, fmt);
+    p += vsprintf(p, fmt, args);
+    va_end(args);
+
+    OSReport("%s", buf);
+}
+
+#define SY_LOG(...) SY_LOG_IMPL(__VA_ARGS__)
+#else
+#define SY_LOG(...) ((void)0)
+#endif
+
 namespace SyringeUtils {
-    u32 EncodeBranch(u32 start, u32 dest, bool linked)
+    inline u32 EncodeBranch(u32 start, u32 dest, bool linked)
     {
         u32 offset;
         if (start > dest)
@@ -17,7 +47,7 @@ namespace SyringeUtils {
         u32 instr = 0x48000000 | offset & 0x3FFFFFF;
         return linked ? instr + 1 : instr;
     }
-    u32 EncodeBranch(u32 start, u32 dest)
+    inline u32 EncodeBranch(u32 start, u32 dest)
     {
         return EncodeBranch(start, dest, false);
     }

--- a/source/coreapi.cpp
+++ b/source/coreapi.cpp
@@ -1,6 +1,8 @@
-#include <OS/OSError.h>
 #include <gf/gf_heap_manager.h>
+#include <gf/gf_module.h>
 #include <vector.h>
+
+#include "sy_utils.hpp"
 
 #include "coreapi.hpp"
 #include "hook.hpp"
@@ -25,11 +27,11 @@ namespace SyringeCore {
         if (hook->getType() == HOOK_STATIC)
         {
             hook->apply(address);
-            OSReport("[Syringe] Patching %8x -> %8x\n", address, (u32)function);
+            SY_LOG("Patching %8x -> %8x\n", address, (u32)function);
         }
         else
         {
-            const gfModuleInfo* moduleInfoArr = g_gfModuleManager->m_moduleInfos;
+            const gfModuleInfo* moduleInfoArr = gfModuleManager::getInstance()->m_moduleInfos;
             for (u32 i = 0; i < 0x10; i++)
             {
                 gfModule* currModule = moduleInfoArr[i].m_module;

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -1,7 +1,8 @@
-#include <OS/OSError.h>
 #include <gf/gf_heap_manager.h>
 #include <gf/gf_module.h>
 #include <string.h>
+
+#include "sy_utils.hpp"
 
 #include "coreapi.hpp"
 #include "hook.hpp"
@@ -67,10 +68,10 @@ bool Plugin::load()
 
     // Check Syringe version compatibility
     this->metadata->VERSION.toString(this->metadata->VERSION, buff);
-    OSReport("[Syringe] Loaded plugin (%s, v%s)\n", this->metadata->NAME, buff);
+    SY_LOG("Loaded plugin (%s, v%s)\n", this->metadata->NAME, buff);
     if (this->metadata->VERSION != Version(SYRINGE_VERSION))
     {
-        OSReport("[Syringe] Warning: Plugin %s was built for Syringe v%s, but current version is v%s. This may cause instability.\n",
+        SY_LOG("Warning: Plugin %s was built for Syringe v%s, but current version is v%s. This may cause instability.\n",
                  this->metadata->NAME, buff, SYRINGE_VERSION);
     }
 
@@ -83,13 +84,13 @@ void Plugin::execute()
 
     // Call the plugin entrypoint
     this->metadata->entrypoint(this);
-    OSReport("[Syringe] Executing plugin (%s)\n", this->metadata->NAME);
+    SY_LOG("Executing plugin (%s)\n", this->metadata->NAME);
 }
 void Plugin::unload()
 {
     if (this->metadata != NULL)
     {
-        OSReport("[Syringe] Unloading plugin (%s)\n", this->metadata->NAME);
+        SY_LOG("Unloading plugin (%s)\n", this->metadata->NAME);
     }
 
     // Restore original instructions for all hooks

--- a/source/rel.cpp
+++ b/source/rel.cpp
@@ -2,6 +2,7 @@
 #include <SO/SOBasic.h>
 
 #include "sy_core.hpp"
+#include "sy_utils.hpp"
 
 extern "C" {
 typedef void (*PFN_voidfunc)();
@@ -25,7 +26,7 @@ void _unresolved();
 
 void _prolog()
 {
-    OSReport("[Syringe] Initializing. (ver. %s)\n", SYRINGE_VERSION);
+    SY_LOG("Initializing. (ver. %s)\n", SYRINGE_VERSION);
 
     // Run global constructors
     PFN_voidfunc* ctor;

--- a/source/sy_core.cpp
+++ b/source/sy_core.cpp
@@ -1,5 +1,4 @@
 #include <FA.h>
-#include <OS/OSError.h>
 
 #include <gf/gf_module.h>
 #include <string.h>
@@ -7,6 +6,7 @@
 
 #include "coreapi.hpp"
 #include "events.hpp"
+#include "sy_utils.hpp"
 #include "plugin.hpp"
 #include "sy_core.hpp"
 
@@ -31,11 +31,11 @@ namespace SyringeCore {
 
         if (hook->getOptions() & OPT_DIRECT)
         {
-            OSReport("[Syringe] Patching %8x -> %8x\n", hook->getInstalledAt(), hook->getDestination());
+            SY_LOG("Patching %8x -> %8x\n", hook->getInstalledAt(), hook->getDestination());
         }
         else
         {
-            OSReport("[Syringe] Patching %8x -> %8x\n", hook->getInstalledAt(), (u32)hook->getPayloadAddr());
+            SY_LOG("Patching %8x -> %8x\n", hook->getInstalledAt(), (u32)hook->getPayloadAddr());
         }
     }
 
@@ -125,7 +125,7 @@ namespace SyringeCore {
 
         if (!plg->load())
         {
-            OSReport("[Syringe] Failed to load plugin (%s)\n", tmp);
+            SY_LOG("Failed to load plugin (%s)\n", tmp);
             return false;
         }
 


### PR DESCRIPTION
## What this does
Logging increases the size of the output binary drastically. Instead of including it always, gate it behind a compiler flag. (default on)

While the DX is better with detailed logging of patch addresses and where each patch leads it is not necessary for the end user to see. During development, developers can use debug builds to restore logging and enable other useful (planned) debug features.

Still not sure this is worth it at the moment, but creating the PR for future use.