### PR TITLE
Dynamically size hook payloads

### DIFF
--- a/include/hook.hpp
+++ b/include/hook.hpp
@@ -30,12 +30,13 @@ namespace SyringeCore {
         u32 moduleId;          // module ID this hook belongs to
         u32 tgtAddr;           // target address to hook (this can be relative)
         u32 newAddr;           // address to branch to
-        u32 instructions[14];  // hook instructions
+        u32* payload;          // dynamically sized payload for non-direct hooks
         Trampoline trampoline; // trampoline to facilitate calling original function
         u32 installedAt;       // address where the hook was actually installed
         u32 originalInstr;     // original instruction at target address
     public:
         Hook(u32 source, u32 dest, u32 moduleId, int options, s32 owner);
+        ~Hook();
         HookType getType() const { return moduleId == -1 ? HOOK_STATIC : HOOK_RELATIVE; }
         HookOptions getOptions() const { return options; }
         u32 getModuleId() const { return moduleId; }
@@ -43,7 +44,7 @@ namespace SyringeCore {
         u32 getDestination() const { return newAddr; }
         u32 getInstalledAt() const { return installedAt; }
         void getTrampoline(void** func) { *func = &trampoline; }
-        void* getPayloadAddr() { return &instructions; }
+        void* getPayloadAddr() { return payload; }
         u32 getOriginalInstr() const { return originalInstr; }
         s32 getOwner() const { return owner; }
 
@@ -51,6 +52,6 @@ namespace SyringeCore {
         void undo();
 
     private:
-        void setInstructions(u32 targetAddr, HookOptions opts);
+        void setInstructions(u32 targetAddr);
     };
 }

--- a/source/hook.cpp
+++ b/source/hook.cpp
@@ -1,4 +1,5 @@
 #include <OS/OSCache.h>
+#include <memory.h>
 
 #include "hook.hpp"
 #include "sy_utils.hpp"
@@ -6,6 +7,7 @@
 namespace SyringeCore {
     // Payload template for hooks that need to save registers
     static const u32 safe_payload[] = {
+        0x60000000, // nop (placeholder for original instruction if OPT_ORIG_PRE is set)
         0x9421FF70, // stwu r1, -0x90(r1)
         0x90010008, // stw r0, 0x8(r1)
         0xBC61000C, // stmw r3, 0xC(r1)
@@ -17,10 +19,13 @@ namespace SyringeCore {
         0x80010008, // lwz r0, 0x8(r1)
         0xB861000C, // lmw r3, 0xC(r1)
         0x38210090, // addi r1, r1, 0x90
+        0x60000000, // nop (placeholder for original instruction if OPT_ORIG_POST is set)
+        0x60000000, // nop (placeholder for final branch instruction)
     };
 
     // Payload template for hooks that don't need to save registers
     static const u32 simple_payload[] = {
+        0x60000000, // nop (placeholder for original instruction if OPT_ORIG_PRE is set)
         0x9421FFF0, // stwu r1, -0x10(r1)
         0x7C0802A6, // mflr r0
         0x90010014, // stw r0, 0x14(r1)
@@ -28,7 +33,28 @@ namespace SyringeCore {
         0x80010014, // lwz r0, 0x14(r1)
         0x7C0803A6, // mtlr r0
         0x38210010, // addi r1, r1, 0x10
+        0x60000000, // nop (placeholder for original instruction if OPT_ORIG_POST is set)
+        0x60000000, // nop (placeholder for final branch instruction)
     };
+
+    // constants for calculating payload sizes and branch instruction indices based on options
+    enum {
+        SAFE_PAYLOAD_WORDS = sizeof(safe_payload) / sizeof(safe_payload[0]),
+        SIMPLE_PAYLOAD_WORDS = sizeof(simple_payload) / sizeof(simple_payload[0]),
+        SAFE_BRANCH_IDX = 6,
+        SIMPLE_BRANCH_IDX = 4
+    };
+
+    static u8 calcPayloadWords(HookOptions opts)
+    {
+        if (opts & OPT_DIRECT)
+            return 0;
+
+        else if (opts & OPT_SAVE_REGS)
+            return SAFE_PAYLOAD_WORDS;
+        else
+            return SIMPLE_PAYLOAD_WORDS;
+    }
 
     Hook::Hook(u32 source, u32 dest, u32 moduleId, int opts, s32 owner)
         : trampoline(Trampoline(0x60000000, 0)),
@@ -37,45 +63,63 @@ namespace SyringeCore {
           options((HookOptions)opts),
           moduleId(moduleId),
           owner(owner),
+          payload(NULL),
           installedAt(NULL)
     {
-        for (u8 i = 0; i < sizeof(instructions) / sizeof(instructions[0]); i++)
+        const u8 words = calcPayloadWords(options);
+        if (words != 0)
         {
-            instructions[i] = 0x60000000; // initialize all instructions to NOP
+            payload = new (Heaps::Syringe) u32[words];
+            memcpy(payload,
+                   (options & OPT_SAVE_REGS) ? safe_payload : simple_payload,
+                   words * sizeof(u32));
         }
     }
-    void Hook::setInstructions(u32 targetAddr, HookOptions opts)
+
+    Hook::~Hook()
     {
-        if (opts & OPT_SAVE_REGS)
+        if (payload != NULL)
         {
-            memcpy(&instructions[1], &safe_payload, sizeof(safe_payload));
-            instructions[6] = SyringeUtils::EncodeBranch((u32)&instructions[6], newAddr, true);
+            delete[] payload;
+            payload = NULL;
         }
-        else
-        {
-            memcpy(&instructions[1], &simple_payload, sizeof(simple_payload));
-            instructions[4] = SyringeUtils::EncodeBranch((u32)&instructions[4], newAddr, true);
-        }
+    }
 
-        // original instruction or nop (ORIG_INSTR_PRE)
-        if (opts & OPT_ORIG_PRE)
-            instructions[0] = originalInstr;
+    /// @brief Updates the hook payload with the correct branch and original instruction (if needed)
+    /// @param targetAddr The address we are hooking
+    void Hook::setInstructions(u32 targetAddr)
+    {
+        // If OPT_DIRECT is set, we don't use a payload
+        if (payload == NULL)
+            return;
 
-        // original instruction or nop (ORIG_INSTR_POST)
-        if (opts & OPT_ORIG_POST)
-            instructions[12] = originalInstr;
+        const bool saveRegs = (options & OPT_SAVE_REGS) != 0;
+        const u8 branchIdx = saveRegs ? SAFE_BRANCH_IDX : SIMPLE_BRANCH_IDX;
+        const u8 postIdx = saveRegs ? (SAFE_PAYLOAD_WORDS - 2) : (SIMPLE_PAYLOAD_WORDS - 2);
+
+        if (options & OPT_ORIG_PRE)
+            payload[0] = originalInstr;
+
+        payload[branchIdx] = SyringeUtils::EncodeBranch((u32)&payload[branchIdx], newAddr);
+
+        // original instruction (ORIG_INSTR_POST)
+        if (options & OPT_ORIG_POST)
+            payload[postIdx] = originalInstr;
 
         // If OPT_NO_RETURN is set, we branch to the link register
-        if (opts & OPT_NO_RETURN)
+        // Otherwise, we branch to the original function + 4
+        if (options & OPT_NO_RETURN)
         {
-            instructions[13] = 0x4E800020; // blr
+            payload[postIdx + 1] = 0x4E800020; // blr
         }
         else
         {
-            // By default, we branch to the original function
-            instructions[13] = SyringeUtils::EncodeBranch((u32)&instructions[13], targetAddr + 4);
+            payload[postIdx + 1] = SyringeUtils::EncodeBranch((u32)&payload[postIdx + 1], targetAddr + 4);
         }
     }
+
+    /// @brief Applies the hook by writing the hook branch to the target address and setting up the payload if needed
+    /// @param address Absolute address of the instruction to hook
     void Hook::apply(u32 address)
     {
         // get original instruction
@@ -93,10 +137,13 @@ namespace SyringeCore {
         else
         {
             // Set the instructions for the hook
-            this->setInstructions(address, options);
+            this->setInstructions(address);
 
             // patch the target address with a branch to our hook instructions
-            *(u32*)address = SyringeUtils::EncodeBranch(address, (u32)&instructions[0]);
+            *(u32*)address = SyringeUtils::EncodeBranch(address, (u32)&payload[0]);
+
+            // invalidate instruction cache for the payload body
+            ICInvalidateRange((void*)payload, calcPayloadWords(options) * sizeof(u32));
         }
 
         // Update the installedAt address
@@ -106,6 +153,7 @@ namespace SyringeCore {
         ICInvalidateRange((void*)address, 0x04);
     }
 
+    /// @brief Undoes the hook by restoring the original instruction at the target address
     void Hook::undo()
     {
         // restore the original instruction at the target address


### PR DESCRIPTION
## What this does
Right now the Hook object is sized to take up the maximum amount of space that could possibly be required by it's options. For example, even if a hook does **not** need a payload, the full 14 instruction payload is allocated as part of the hook itself. This leads to massive wastes in heap usage.

## Solution
Instead of embedding the payload as part of the Hook object itself, we allocate the payload on the heap. This way, we can size the object to match the exact needs of the hook. Meaning safe hooks will get the full size payload, simple hooks will get the reduced payload, and direct hooks will get no payload at all.

## Results
Reduced overall heap usage by virtue of not allocating the full 14 instructions for every Hook. Many hooks can be either `simple` or `direct` or be refactored into them leading to more efficient memory usage.